### PR TITLE
feat: 채팅방 초대 링크 기능 구현

### DIFF
--- a/.github/git-commit-instructions.md
+++ b/.github/git-commit-instructions.md
@@ -1,0 +1,101 @@
+# GitHub Copilot Commit Instructions
+
+This repository follows the **[Conventional Commits 1.0.0 specification](https://www.conventionalcommits.org/en/v1.0.0/)**.  
+All commit messages **MUST** conform to the rules below so we can maintain a clear commit history, generate changelogs, and automate versioning.
+
+## Commit Message Format
+
+```
+<type>[optional scope][!]: <short description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Examples
+- `feat: add user login API`
+- `fix(parser): handle null values correctly`
+- `docs: update installation guide`
+- `chore!: drop support for Node 16`
+
+```
+fix: prevent race condition in request handling
+
+Introduce request ID and reference to latest request.
+Ignore responses from outdated requests.
+
+BREAKING CHANGE: timeout configuration option was removed.
+```
+
+---
+
+## Allowed Types
+
+- **feat**: a new feature (correlates with `MINOR` in SemVer).
+- **fix**: a bug fix (correlates with `PATCH` in SemVer).
+- **docs**: documentation changes only.
+- **style**: formatting changes, no code logic impact (e.g., whitespace, semicolons).
+- **refactor**: code change that neither fixes a bug nor adds a feature.
+- **perf**: performance improvement.
+- **test**: add or update tests only.
+- **build**: changes to build system or dependencies.
+- **ci**: CI/CD configuration or scripts.
+- **chore**: other changes that don’t affect `src` or `test`.
+- **revert**: revert a previous commit.
+
+---
+
+## Breaking Changes
+
+Breaking changes **MUST** be indicated by:
+- Adding a `!` after the type/scope  
+  Example:
+  ```
+  feat(api)!: update response format
+  ```
+- OR adding a `BREAKING CHANGE:` footer  
+  Example:
+  ```
+  fix: adjust config loading order
+
+  BREAKING CHANGE: environment variables now override config files
+  ```
+
+---
+
+## Commit Body (Optional)
+
+- Provide additional context if needed.
+- Start body **after a blank line**.
+- Use multiple paragraphs if necessary.
+
+---
+
+## Commit Footers (Optional)
+
+- Follow [git trailer format](https://git-scm.com/docs/git-interpret-trailers).
+- Examples:
+  ```
+  Reviewed-by: Alice
+  Refs: #123
+  ```
+
+---
+
+## Instructions for GitHub Copilot
+
+When generating commit messages with Copilot:
+1. **Always start with `<type>`** (e.g., feat, fix, docs).
+2. **Keep description short (≤72 characters)**.
+3. Add body text if explaining “why” is important.
+4. Add `BREAKING CHANGE:` footer if necessary.
+5. Use correct casing and punctuation consistently.
+
+---
+
+✅ Following these rules ensures:
+- Automated **changelog generation**.
+- Proper **semantic versioning** (SemVer).
+- Easier collaboration and contribution.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,111 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.3.0] - 2026-01-17
+
+### Added
+
+#### Room Invite Link (채팅방 초대 링크)
+- 채팅방별 고유 초대 링크 생성 기능
+  - 8자리 영숫자 초대 코드 생성
+  - Valkey(Redis) 기반 저장 (7일 TTL 자동 만료)
+- Backend API
+  - `POST /api/v1/rooms/{roomId}/invites`: 초대 코드 생성
+  - `GET /api/v1/invites/{code}`: 초대 정보 조회 (공개)
+  - `POST /api/v1/invites/{code}/join`: 초대 코드로 참여
+  - `DELETE /api/v1/invites/{code}`: 초대 코드 삭제
+- `RoomInviteService`: Valkey 기반 초대 비즈니스 로직
+- `RoomInviteController`: 초대 API 엔드포인트
+- `RoomInviteResponse` DTO
+
+#### Frontend
+- `InvitePage`: 초대 참여 페이지 (`/invite/:code`)
+  - 채팅방 정보 표시
+  - 미로그인 시 로그인 페이지 리다이렉트 (returnUrl 포함)
+  - 이미 참여한 채팅방은 바로 이동
+- `inviteApi`: 초대 API 클라이언트
+- `ChatRoom` 헤더에 "초대 링크" 버튼 추가
+  - 클릭 시 초대 링크 생성 및 클립보드 복사
+  - "복사됨" 피드백 표시
+
+### Changed
+
+#### Backend
+- `SecurityConfig`: `/api/v1/invites/{code}` GET 요청 공개 설정
+
+### Fixed
+
+#### Backend - Reactive Stream 중복 실행 방지
+- `RoomInviteService`: `.cache()` 연산자 추가로 Mono 중복 구독 시 중복 실행 방지
+- `MessageService`: `getMessages()` 메서드에 `.cache()` 추가
+  - 동일 요청 ID로 두 번 처리되어 `UnsupportedOperationException: ServerHttpResponse already committed` 발생하던 문제 해결
+
+#### Frontend
+- `ChatRoom`: `useRef` 기반 즉각적인 중복 클릭 방지 (초대 링크 버튼)
+- `MessageInput`: 한글 IME 조합 중 Enter 키 처리 문제 해결
+  - `e.nativeEvent.isComposing` 체크 추가
+  - 한글 입력 중 Enter 시 메시지가 분리되던 버그 수정 (예: "머냐 이거 버그냐" → "머냐 이거 버그냐", "냐")
+
+---
+
+## [0.2.0] - 2026-01-17
+
+### Added
+
+#### Authentication (Google OAuth 2.0 + JWT)
+- Google OAuth 2.0 로그인 구현
+  - `AuthController`: OAuth URL 반환, 콜백 처리, 토큰 갱신
+  - `AuthService`: Google 사용자 정보 조회, 사용자 생성/조회
+  - `JwtService`: Access Token / Refresh Token 생성 및 검증
+- 최초 로그인 시 자동 사용자 등록 (users 테이블에 OAuth 정보 저장)
+- JWT 기반 API 인증
+  - `JwtAuthenticationFilter`: 요청별 토큰 검증
+  - `@AuthenticationPrincipal User user`: 컨트롤러에서 인증된 사용자 주입
+- Spring Security WebFlux 설정
+  - Public: `/api/v1/auth/**`, `/api/v1/avatar/**`, `/ws/**`
+  - Protected: `/api/v1/**` (인증 필요)
+
+#### Frontend Auth
+- `useAuthStore`: 인증 상태 관리 (Zustand + persist)
+- `LoginPage`: Google 로그인 버튼
+- `AuthCallbackPage`: OAuth 콜백 처리 및 토큰 저장
+- API 클라이언트 `Authorization: Bearer {token}` 헤더 자동 추가
+- 401 응답 시 자동 로그아웃 및 로그인 페이지 리다이렉트
+- 로그아웃 버튼 (Sidebar)
+
+#### Avatar Image Proxy
+- `AvatarService`: Google 프로필 이미지 다운로드 및 Valkey 캐싱
+  - Base64 인코딩으로 Valkey에 저장
+  - 24시간 TTL 캐시
+- `AvatarController`: `GET /api/v1/avatar/{userId}` 엔드포인트
+- 프론트엔드 `getAvatarUrl(userId)` 유틸리티 함수
+- Google 이미지 서버 429 에러 방지
+
+#### UX Improvements
+- 로그인 시 자동 WebSocket 연결 (`shouldConnect` 기본값 true)
+- Avatar 이미지 로드 실패 시 fallback 표시 및 재요청 방지
+
+### Changed
+
+#### Backend
+- `ChatRoomController`: `@RequestHeader("X-User-Id")` → `@AuthenticationPrincipal User user`
+- `MessageController`: `@RequestHeader("X-User-Id")` → `@AuthenticationPrincipal User user`
+- `ChatWebSocketHandler`: `?userId=` → `?token=` JWT 토큰 인증 방식
+- `schema.sql`: OAuth 관련 컬럼 추가 (email, oauth_provider, oauth_id)
+
+#### Frontend
+- Avatar 컴포넌트: Google URL → 서버 프록시 URL
+- WebSocket 연결: `?userId=` → `?token=` JWT 토큰 방식
+
+### Security
+- JWT 토큰 기반 stateless 인증
+- Access Token: 1시간, Refresh Token: 7일
+- CSRF 비활성화 (stateless API)
+
+---
+
 ## [0.1.0] - 2026-01-17
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ git checkout -b feature/6
 
 ## Commit Convention
 
+[git-commit-instructions](.github/git-commit-instructions.md)
+
 ### 커밋 메시지 형식
 
 ```

--- a/backend/src/main/java/com/messenger/chatroom/controller/RoomInviteController.java
+++ b/backend/src/main/java/com/messenger/chatroom/controller/RoomInviteController.java
@@ -1,0 +1,47 @@
+package com.messenger.chatroom.controller;
+
+import com.messenger.chatroom.dto.ChatRoomResponse;
+import com.messenger.chatroom.dto.RoomInviteResponse;
+import com.messenger.chatroom.service.RoomInviteService;
+import com.messenger.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class RoomInviteController {
+
+    private final RoomInviteService roomInviteService;
+
+    @PostMapping("/rooms/{roomId}/invites")
+    @ResponseStatus(HttpStatus.CREATED)
+    public Mono<RoomInviteResponse> createInvite(
+            @PathVariable UUID roomId,
+            @AuthenticationPrincipal User user) {
+        return roomInviteService.createInvite(roomId, user.getId());
+    }
+
+    @GetMapping("/invites/{code}")
+    public Mono<RoomInviteResponse> getInviteByCode(@PathVariable String code) {
+        return roomInviteService.getInviteByCode(code);
+    }
+
+    @PostMapping("/invites/{code}/join")
+    public Mono<ChatRoomResponse> joinByInviteCode(
+            @PathVariable String code,
+            @AuthenticationPrincipal User user) {
+        return roomInviteService.joinByInviteCode(code, user.getId());
+    }
+
+    @DeleteMapping("/invites/{code}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public Mono<Void> deleteInvite(@PathVariable String code) {
+        return roomInviteService.deleteInvite(code).then();
+    }
+}

--- a/backend/src/main/java/com/messenger/chatroom/dto/RoomInviteResponse.java
+++ b/backend/src/main/java/com/messenger/chatroom/dto/RoomInviteResponse.java
@@ -1,0 +1,22 @@
+package com.messenger.chatroom.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoomInviteResponse {
+
+    private UUID roomId;
+    private String roomName;
+    private String inviteCode;
+    private String inviteUrl;
+    private OffsetDateTime createdAt;
+}

--- a/backend/src/main/java/com/messenger/chatroom/service/RoomInviteService.java
+++ b/backend/src/main/java/com/messenger/chatroom/service/RoomInviteService.java
@@ -1,0 +1,123 @@
+package com.messenger.chatroom.service;
+
+import com.messenger.chatroom.dto.ChatRoomResponse;
+import com.messenger.chatroom.dto.RoomInviteResponse;
+import com.messenger.chatroom.entity.RoomMember;
+import com.messenger.chatroom.repository.ChatRoomRepository;
+import com.messenger.chatroom.repository.RoomMemberRepository;
+import com.messenger.common.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RoomInviteService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final RoomMemberRepository roomMemberRepository;
+    private final ReactiveRedisTemplate<String, String> redisTemplate;
+
+    private static final String INVITE_KEY_PREFIX = "invite:";
+    private static final Duration INVITE_TTL = Duration.ofDays(7);
+
+    @Value("${app.frontend-url:http://localhost:5173}")
+    private String frontendUrl;
+
+    public Mono<RoomInviteResponse> createInvite(UUID roomId, UUID userId) {
+        return chatRoomRepository.findById(roomId)
+                .switchIfEmpty(Mono.error(new BusinessException("ROOM_NOT_FOUND", "Chat room not found")))
+                .flatMap(room -> roomMemberRepository.existsByRoomIdAndUserId(roomId, userId)
+                        .flatMap(isMember -> {
+                            if (!isMember) {
+                                return Mono.error(new BusinessException("NOT_A_MEMBER", "You are not a member of this room"));
+                            }
+
+                            String inviteCode = generateInviteCode();
+                            String cacheKey = INVITE_KEY_PREFIX + inviteCode;
+
+                            return redisTemplate.opsForValue()
+                                    .set(cacheKey, roomId.toString(), INVITE_TTL)
+                                    .map(success -> RoomInviteResponse.builder()
+                                            .roomId(roomId)
+                                            .roomName(room.getName())
+                                            .inviteCode(inviteCode)
+                                            .inviteUrl(frontendUrl + "/invite/" + inviteCode)
+                                            .createdAt(OffsetDateTime.now())
+                                            .build());
+                        }))
+                .doOnSuccess(r -> log.info("Invite created for room: {} with code: {}", roomId, r.getInviteCode()))
+                .cache();
+    }
+
+    public Mono<RoomInviteResponse> getInviteByCode(String inviteCode) {
+        String cacheKey = INVITE_KEY_PREFIX + inviteCode;
+
+        return redisTemplate.opsForValue().get(cacheKey)
+                .switchIfEmpty(Mono.error(new BusinessException("INVITE_NOT_FOUND", "Invite code not found or expired")))
+                .flatMap(roomIdStr -> {
+                    UUID roomId = UUID.fromString(roomIdStr);
+                    return chatRoomRepository.findById(roomId)
+                            .switchIfEmpty(Mono.error(new BusinessException("ROOM_NOT_FOUND", "Chat room not found")))
+                            .map(room -> RoomInviteResponse.builder()
+                                    .roomId(roomId)
+                                    .roomName(room.getName())
+                                    .inviteCode(inviteCode)
+                                    .inviteUrl(frontendUrl + "/invite/" + inviteCode)
+                                    .build());
+                });
+    }
+
+    @Transactional
+    public Mono<ChatRoomResponse> joinByInviteCode(String inviteCode, UUID userId) {
+        String cacheKey = INVITE_KEY_PREFIX + inviteCode;
+
+        return redisTemplate.opsForValue().get(cacheKey)
+                .switchIfEmpty(Mono.error(new BusinessException("INVITE_NOT_FOUND", "Invite code not found or expired")))
+                .flatMap(roomIdStr -> {
+                    UUID roomId = UUID.fromString(roomIdStr);
+                    return chatRoomRepository.findById(roomId)
+                            .switchIfEmpty(Mono.error(new BusinessException("ROOM_NOT_FOUND", "Chat room not found")))
+                            .flatMap(room -> roomMemberRepository.existsByRoomIdAndUserId(roomId, userId)
+                                    .flatMap(isMember -> {
+                                        if (isMember) {
+                                            // Already a member, just return the room info
+                                            return roomMemberRepository.countByRoomId(roomId)
+                                                    .map(count -> ChatRoomResponse.from(room, count));
+                                        }
+
+                                        // Add as new member
+                                        RoomMember member = RoomMember.builder()
+                                                .roomId(roomId)
+                                                .userId(userId)
+                                                .role("MEMBER")
+                                                .joinedAt(OffsetDateTime.now())
+                                                .build();
+
+                                        return roomMemberRepository.save(member)
+                                                .then(roomMemberRepository.countByRoomId(roomId))
+                                                .map(count -> ChatRoomResponse.from(room, count));
+                                    }));
+                })
+                .doOnSuccess(r -> log.info("User {} joined room {} via invite code", userId, r.getId()));
+    }
+
+    public Mono<Boolean> deleteInvite(String inviteCode) {
+        String cacheKey = INVITE_KEY_PREFIX + inviteCode;
+        return redisTemplate.delete(cacheKey)
+                .map(count -> count > 0);
+    }
+
+    private String generateInviteCode() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    }
+}

--- a/backend/src/main/java/com/messenger/config/SecurityConfig.java
+++ b/backend/src/main/java/com/messenger/config/SecurityConfig.java
@@ -41,6 +41,8 @@ public class SecurityConfig {
                 .authorizeExchange(exchanges -> exchanges
                         // Public endpoints
                         .pathMatchers("/api/v1/auth/**").permitAll()
+                        .pathMatchers("/api/v1/avatar/**").permitAll()
+                        .pathMatchers(HttpMethod.GET, "/api/v1/invites/{code}").permitAll()
                         .pathMatchers("/ws/**").permitAll()
                         .pathMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         // Protected endpoints

--- a/backend/src/main/java/com/messenger/message/service/MessageService.java
+++ b/backend/src/main/java/com/messenger/message/service/MessageService.java
@@ -80,7 +80,7 @@ public class MessageService {
                                     : null)
                             .hasMore(hasMore)
                             .build());
-        });
+        }).cache();
     }
 
     public Mono<Void> deleteMessage(UUID messageId, UUID userId) {

--- a/backend/src/main/java/com/messenger/user/controller/AvatarController.java
+++ b/backend/src/main/java/com/messenger/user/controller/AvatarController.java
@@ -1,0 +1,38 @@
+package com.messenger.user.controller;
+
+import com.messenger.user.service.AvatarService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.CacheControl;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/avatar")
+@RequiredArgsConstructor
+public class AvatarController {
+
+    private final AvatarService avatarService;
+
+    @GetMapping(value = "/{userId}", produces = {MediaType.IMAGE_PNG_VALUE, MediaType.IMAGE_JPEG_VALUE})
+    public Mono<ResponseEntity<byte[]>> getAvatar(@PathVariable UUID userId) {
+        return avatarService.getAvatarByUserId(userId)
+                .map(imageBytes -> ResponseEntity.ok()
+                        .cacheControl(CacheControl.maxAge(Duration.ofHours(24)).cachePublic())
+                        .contentType(MediaType.IMAGE_PNG)
+                        .body(imageBytes))
+                .defaultIfEmpty(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{userId}/cache")
+    public Mono<ResponseEntity<Void>> invalidateCache(@PathVariable UUID userId) {
+        return avatarService.invalidateCache(userId)
+                .map(success -> success
+                        ? ResponseEntity.noContent().<Void>build()
+                        : ResponseEntity.notFound().<Void>build());
+    }
+}

--- a/backend/src/main/java/com/messenger/user/service/AvatarService.java
+++ b/backend/src/main/java/com/messenger/user/service/AvatarService.java
@@ -1,0 +1,76 @@
+package com.messenger.user.service;
+
+import com.messenger.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.Base64;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AvatarService {
+
+    private final UserRepository userRepository;
+    private final ReactiveRedisTemplate<String, String> redisTemplate;
+    private final WebClient webClient = WebClient.builder()
+            .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(5 * 1024 * 1024)) // 5MB
+            .build();
+
+    private static final String AVATAR_CACHE_PREFIX = "avatar:";
+    private static final Duration CACHE_TTL = Duration.ofHours(24);
+
+    public Mono<byte[]> getAvatarByUserId(UUID userId) {
+        String cacheKey = AVATAR_CACHE_PREFIX + userId;
+
+        return redisTemplate.opsForValue().get(cacheKey)
+                .map(base64 -> Base64.getDecoder().decode(base64))
+                .switchIfEmpty(fetchAndCacheAvatar(userId, cacheKey));
+    }
+
+    private Mono<byte[]> fetchAndCacheAvatar(UUID userId, String cacheKey) {
+        return userRepository.findById(userId)
+                .flatMap(user -> {
+                    String avatarUrl = user.getAvatarUrl();
+                    if (avatarUrl == null || avatarUrl.isBlank()) {
+                        log.debug("User {} has no avatar URL", userId);
+                        return Mono.empty();
+                    }
+
+                    log.info("Fetching avatar for user {} from {}", userId, avatarUrl);
+                    return fetchImageFromUrl(avatarUrl)
+                            .flatMap(imageBytes -> cacheAvatar(cacheKey, imageBytes)
+                                    .thenReturn(imageBytes));
+                });
+    }
+
+    private Mono<byte[]> fetchImageFromUrl(String url) {
+        return webClient.get()
+                .uri(url)
+                .accept(MediaType.IMAGE_JPEG, MediaType.IMAGE_PNG, MediaType.IMAGE_GIF)
+                .retrieve()
+                .bodyToMono(byte[].class)
+                .doOnError(e -> log.error("Failed to fetch image from {}: {}", url, e.getMessage()))
+                .onErrorResume(e -> Mono.empty());
+    }
+
+    private Mono<Boolean> cacheAvatar(String cacheKey, byte[] imageBytes) {
+        String base64 = Base64.getEncoder().encodeToString(imageBytes);
+        return redisTemplate.opsForValue()
+                .set(cacheKey, base64, CACHE_TTL)
+                .doOnSuccess(success -> log.debug("Cached avatar: {}", cacheKey));
+    }
+
+    public Mono<Boolean> invalidateCache(UUID userId) {
+        String cacheKey = AVATAR_CACHE_PREFIX + userId;
+        return redisTemplate.delete(cacheKey)
+                .map(count -> count > 0);
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import { AppLayout } from '@/components/layout/AppLayout';
 import { LoginPage } from '@/pages/LoginPage';
 import { AuthCallbackPage } from '@/pages/AuthCallbackPage';
+import { InvitePage } from '@/pages/InvitePage';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { useChatStore } from '@/stores/useChatStore';
 import { roomApi } from '@/api';
@@ -91,6 +92,7 @@ function App() {
         }
       />
       <Route path="/auth/callback" element={<AuthCallbackPage />} />
+      <Route path="/invite/:code" element={<InvitePage />} />
       <Route
         path="/"
         element={

--- a/frontend/src/api/inviteApi.ts
+++ b/frontend/src/api/inviteApi.ts
@@ -1,0 +1,20 @@
+import apiClient from './client';
+import type { ChatRoom, RoomInviteResponse } from '@/types';
+
+export const inviteApi = {
+  create: (roomId: string): Promise<RoomInviteResponse> => {
+    return apiClient.post<RoomInviteResponse>(`/rooms/${roomId}/invites`);
+  },
+
+  getByCode: (code: string): Promise<RoomInviteResponse> => {
+    return apiClient.get<RoomInviteResponse>(`/invites/${code}`);
+  },
+
+  join: (code: string): Promise<ChatRoom> => {
+    return apiClient.post<ChatRoom>(`/invites/${code}/join`);
+  },
+
+  delete: (code: string): Promise<void> => {
+    return apiClient.delete(`/invites/${code}`);
+  },
+};

--- a/frontend/src/components/chat/MessageInput.tsx
+++ b/frontend/src/components/chat/MessageInput.tsx
@@ -26,6 +26,9 @@ export function MessageInput() {
   }, [message, isConnected, currentRoomId, sendChatMessage, sendTypingStatus]);
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    // IME 조합 중에는 Enter 무시 (한글 등)
+    if (e.nativeEvent.isComposing) return;
+
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSend();

--- a/frontend/src/components/chat/MessageItem.tsx
+++ b/frontend/src/components/chat/MessageItem.tsx
@@ -3,6 +3,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { useChatStore } from '@/stores/useChatStore';
 import type { Message } from '@/types';
 import { cn } from '@/lib/utils';
+import { getAvatarUrl } from '@/lib/avatar';
 
 interface MessageItemProps {
   message: Message;
@@ -28,7 +29,7 @@ export const MessageItem = memo(function MessageItem({ message }: MessageItemPro
       )}
     >
       <Avatar className="h-8 w-8 flex-shrink-0">
-        <AvatarImage src={message.sender.avatarUrl} />
+        <AvatarImage src={getAvatarUrl(message.sender.id)} />
         <AvatarFallback>
           {message.sender.displayName.charAt(0).toUpperCase()}
         </AvatarFallback>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,10 +1,12 @@
 import { useChatStore } from '@/stores/useChatStore';
+import { useAuthStore } from '@/stores/useAuthStore';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { CreateRoomModal } from '@/components/chat/CreateRoomModal';
 import { cn } from '@/lib/utils';
-import { MessageSquare, Wifi, WifiOff } from 'lucide-react';
+import { getAvatarUrl } from '@/lib/avatar';
+import { MessageSquare, Wifi, WifiOff, LogOut } from 'lucide-react';
 
 export function Sidebar() {
   const {
@@ -17,8 +19,15 @@ export function Sidebar() {
     setShouldConnect,
   } = useChatStore();
 
+  const logout = useAuthStore((state) => state.logout);
+
   const handleToggleConnection = () => {
     setShouldConnect(!shouldConnect);
+  };
+
+  const handleLogout = () => {
+    logout();
+    window.location.href = '/login';
   };
 
   return (
@@ -27,7 +36,7 @@ export function Sidebar() {
       <div className="p-4 border-b">
         <div className="flex items-center gap-3">
           <Avatar>
-            <AvatarImage src={currentUser?.avatarUrl} />
+            <AvatarImage src={getAvatarUrl(currentUser?.id)} />
             <AvatarFallback>
               {currentUser?.displayName?.charAt(0).toUpperCase() || '?'}
             </AvatarFallback>
@@ -38,7 +47,8 @@ export function Sidebar() {
             </p>
             <p className={cn(
               'text-xs',
-              connectionStatus === 'connected' ? 'text-green-500' : 'text-muted-foreground'
+              connectionStatus === 'connected' ? 'text-green-500' :
+              connectionStatus === 'disconnected' ? 'text-rose-500' : 'text-muted-foreground'
             )}>
               {connectionStatus === 'connected' ? '온라인' :
                connectionStatus === 'connecting' ? '연결 중...' : '오프라인'}
@@ -49,7 +59,10 @@ export function Sidebar() {
             size="icon"
             onClick={handleToggleConnection}
             title={shouldConnect ? '연결 끊기' : '서버 연결'}
-            className="flex-shrink-0"
+            className={cn(
+              'flex-shrink-0',
+              connectionStatus === 'disconnected' && 'border-rose-300 text-rose-500 hover:bg-rose-50 hover:text-rose-600'
+            )}
           >
             {connectionStatus === 'connected' ? (
               <Wifi className="h-4 w-4" />
@@ -58,6 +71,15 @@ export function Sidebar() {
             ) : (
               <WifiOff className="h-4 w-4" />
             )}
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleLogout}
+            title="로그아웃"
+            className="flex-shrink-0"
+          >
+            <LogOut className="h-4 w-4" />
           </Button>
         </div>
       </div>

--- a/frontend/src/components/ui/avatar.tsx
+++ b/frontend/src/components/ui/avatar.tsx
@@ -3,6 +3,9 @@ import * as AvatarPrimitive from "@radix-ui/react-avatar"
 
 import { cn } from "@/lib/utils"
 
+// 에러 발생한 이미지 URL 캐싱 (429 에러 방지)
+const failedImageUrls = new Set<string>();
+
 function Avatar({
   className,
   ...props
@@ -21,12 +24,31 @@ function Avatar({
 
 function AvatarImage({
   className,
+  src,
   ...props
 }: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  const [hasError, setHasError] = React.useState(false);
+
+  // 이미 실패한 URL이면 렌더링하지 않음
+  const shouldRender = src && !hasError && !failedImageUrls.has(src);
+
+  const handleError = React.useCallback(() => {
+    if (src) {
+      failedImageUrls.add(src);
+    }
+    setHasError(true);
+  }, [src]);
+
+  if (!shouldRender) {
+    return null;
+  }
+
   return (
     <AvatarPrimitive.Image
       data-slot="avatar-image"
       className={cn("aspect-square size-full", className)}
+      src={src}
+      onError={handleError}
       {...props}
     />
   )

--- a/frontend/src/pages/InvitePage.tsx
+++ b/frontend/src/pages/InvitePage.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useAuthStore } from '@/stores/useAuthStore';
+import { useChatStore } from '@/stores/useChatStore';
+import { inviteApi } from '@/api/inviteApi';
+import { Button } from '@/components/ui/button';
+import type { RoomInviteResponse } from '@/types';
+import { MessageSquare, Users } from 'lucide-react';
+
+export function InvitePage() {
+  const { code } = useParams<{ code: string }>();
+  const navigate = useNavigate();
+  const { isAuthenticated } = useAuthStore();
+  const { setCurrentRoomId, fetchRooms } = useChatStore();
+
+  const [invite, setInvite] = useState<RoomInviteResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isJoining, setIsJoining] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchInvite = async () => {
+      if (!code) {
+        setError('잘못된 초대 링크입니다.');
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const data = await inviteApi.getByCode(code);
+        setInvite(data);
+      } catch (err) {
+        console.error('Failed to fetch invite:', err);
+        setError('초대 링크를 찾을 수 없거나 만료되었습니다.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchInvite();
+  }, [code]);
+
+  const handleJoin = async () => {
+    if (!code) return;
+
+    if (!isAuthenticated) {
+      // Save the return URL and redirect to login
+      const returnUrl = encodeURIComponent(window.location.pathname);
+      navigate(`/login?returnUrl=${returnUrl}`);
+      return;
+    }
+
+    setIsJoining(true);
+    try {
+      const room = await inviteApi.join(code);
+      await fetchRooms();
+      setCurrentRoomId(room.id);
+      navigate('/');
+    } catch (err) {
+      console.error('Failed to join room:', err);
+      setError('채팅방 참여에 실패했습니다.');
+    } finally {
+      setIsJoining(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-100">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+          <p className="mt-4 text-gray-600">초대 정보를 불러오는 중...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-100">
+        <div className="max-w-md w-full p-8 bg-white rounded-lg shadow-lg text-center">
+          <div className="text-red-500 mb-4">
+            <svg className="w-16 h-16 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+          </div>
+          <h2 className="text-xl font-bold text-gray-900 mb-2">오류</h2>
+          <p className="text-gray-600 mb-6">{error}</p>
+          <Button onClick={() => navigate('/')} variant="outline">
+            홈으로 돌아가기
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <div className="max-w-md w-full p-8 bg-white rounded-lg shadow-lg">
+        <div className="text-center mb-6">
+          <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
+            <MessageSquare className="w-8 h-8 text-primary" />
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900">채팅방 초대</h1>
+          <p className="mt-2 text-gray-600">아래 채팅방에 초대되었습니다</p>
+        </div>
+
+        {invite && (
+          <div className="bg-gray-50 rounded-lg p-4 mb-6">
+            <div className="flex items-center gap-3">
+              <div className="w-12 h-12 bg-secondary rounded-full flex items-center justify-center">
+                <Users className="w-6 h-6 text-muted-foreground" />
+              </div>
+              <div>
+                <h2 className="font-semibold text-gray-900">{invite.roomName}</h2>
+                <p className="text-sm text-gray-500">
+                  초대 코드: {invite.inviteCode}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <Button
+          onClick={handleJoin}
+          disabled={isJoining}
+          className="w-full py-6"
+        >
+          {isJoining ? '참여 중...' : isAuthenticated ? '채팅방 참여하기' : '로그인하고 참여하기'}
+        </Button>
+
+        {!isAuthenticated && (
+          <p className="mt-4 text-center text-sm text-gray-500">
+            채팅방에 참여하려면 로그인이 필요합니다.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/stores/useChatStore.ts
+++ b/frontend/src/stores/useChatStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { roomApi } from '@/api';
 import type { Message, ChatRoom, User } from '@/types';
 
 interface ChatState {
@@ -14,6 +15,7 @@ interface ChatState {
   rooms: ChatRoom[];
   setRooms: (rooms: ChatRoom[]) => void;
   addRoom: (room: ChatRoom) => void;
+  fetchRooms: () => Promise<void>;
 
   // 메시지 (roomId별로 관리)
   messagesByRoom: Record<string, Message[]>;
@@ -46,6 +48,14 @@ export const useChatStore = create<ChatState>((set) => ({
   rooms: [],
   setRooms: (rooms) => set({ rooms }),
   addRoom: (room) => set((state) => ({ rooms: [...state.rooms, room] })),
+  fetchRooms: async () => {
+    try {
+      const rooms = await roomApi.getAll();
+      set({ rooms });
+    } catch (error) {
+      console.error('Failed to fetch rooms:', error);
+    }
+  },
 
   // 메시지
   messagesByRoom: {},
@@ -85,7 +95,7 @@ export const useChatStore = create<ChatState>((set) => ({
   connectionStatus: 'disconnected',
   setConnectionStatus: (status) => set({ connectionStatus: status }),
 
-  // 수동 연결 제어
-  shouldConnect: false,
+  // 연결 제어 (기본값 true: 로그인 시 자동 연결)
+  shouldConnect: true,
   setShouldConnect: (shouldConnect) => set({ shouldConnect }),
 }));

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -41,6 +41,15 @@ export interface Message {
   createdAt: string;
 }
 
+// RoomInvite 타입
+export interface RoomInviteResponse {
+  roomId: string;
+  roomName: string;
+  inviteCode: string;
+  inviteUrl: string;
+  createdAt?: string;
+}
+
 // WebSocket 메시지 타입
 export type MessageType = 'CHAT' | 'JOIN' | 'LEAVE' | 'TYPING' | 'USER_JOINED' | 'USER_LEFT' | 'ERROR';
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,4 +11,9 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  server: {
+    allowedHosts: [
+      '.ngrok-free.app'
+    ]
+  },
 })

--- a/issues/007-room-invite-link.md
+++ b/issues/007-room-invite-link.md
@@ -1,0 +1,179 @@
+# 채팅방 초대 링크 기능 구현
+
+## 개요
+
+채팅방별 고유 초대 링크를 생성하여 공유하면, 링크를 받은 사용자가 해당 채팅방에 참여할 수 있는 기능
+
+## 배경
+
+현재 채팅방은 생성자만 입장할 수 있으며, 다른 사용자를 초대하는 기능이 없습니다.
+초대 링크를 통해 다른 사용자가 채팅방에 쉽게 참여할 수 있도록 합니다.
+
+## 사용자 플로우
+
+```
+1. 채팅방 소유자가 "초대 링크 복사" 버튼 클릭
+2. 초대 링크 생성: http://localhost:5173/invite/{code}
+3. 링크를 외부에서 공유 (카카오톡, 이메일 등)
+4. 링크를 받은 사용자가 클릭
+5. 로그인 상태 확인 → 미로그인 시 로그인 페이지로
+6. 채팅방 정보 확인 후 "참여하기" 버튼 클릭
+7. 채팅방 멤버로 추가 → 채팅방으로 이동
+```
+
+## 기술 결정
+
+### 저장소: Valkey (Redis)
+
+PostgreSQL 테이블 대신 Valkey를 사용하는 이유:
+- **자동 만료**: TTL 설정으로 7일 후 자동 삭제
+- **간단한 구조**: 별도 테이블/마이그레이션 불필요
+- **일시적 데이터**: 초대 링크는 영구 저장 불필요
+
+**저장 구조:**
+```
+Key: invite:{inviteCode}
+Value: {roomId}
+TTL: 7일
+```
+
+## 작업 내용
+
+### Backend
+
+#### 1. 신규 파일
+
+| 파일 | 설명 |
+|------|------|
+| `chatroom/dto/RoomInviteResponse.java` | 초대 응답 DTO |
+| `chatroom/service/RoomInviteService.java` | Valkey 기반 초대 비즈니스 로직 |
+| `chatroom/controller/RoomInviteController.java` | 초대 API 컨트롤러 |
+
+#### 2. DTO (`RoomInviteResponse.java`)
+
+```java
+@Data
+@Builder
+public class RoomInviteResponse {
+    private UUID roomId;
+    private String roomName;
+    private String inviteCode;
+    private String inviteUrl;
+    private OffsetDateTime createdAt;
+}
+```
+
+#### 3. Service (`RoomInviteService.java`)
+
+| 메서드 | 기능 |
+|--------|------|
+| `createInvite(roomId, userId)` | 초대 코드 생성 및 Valkey 저장 |
+| `getInviteByCode(code)` | Valkey에서 초대 정보 조회 |
+| `joinByInviteCode(code, userId)` | 초대 코드로 채팅방 참여 |
+| `deleteInvite(code)` | 초대 코드 삭제 |
+
+**초대 코드 생성 방식:**
+- 8자리 영숫자 랜덤 코드 (예: `a1b2c3d4`)
+- `UUID.randomUUID().toString().replace("-", "").substring(0, 8)`
+
+#### 4. Controller (`RoomInviteController.java`)
+
+| Method | Endpoint | 설명 | 인증 |
+|--------|----------|------|------|
+| POST | `/api/v1/rooms/{roomId}/invites` | 초대 코드 생성 | 필요 |
+| GET | `/api/v1/invites/{code}` | 초대 정보 조회 | 불필요 |
+| POST | `/api/v1/invites/{code}/join` | 초대 코드로 참여 | 필요 |
+| DELETE | `/api/v1/invites/{code}` | 초대 코드 삭제 | 필요 |
+
+#### 5. SecurityConfig 수정
+
+```java
+.pathMatchers(HttpMethod.GET, "/api/v1/invites/{code}").permitAll()  // 초대 정보는 공개
+```
+
+### Frontend
+
+#### 1. 신규 파일
+
+| 파일 | 설명 |
+|------|------|
+| `api/inviteApi.ts` | 초대 API 클라이언트 |
+| `pages/InvitePage.tsx` | 초대 참여 페이지 |
+
+#### 2. API 클라이언트 (`inviteApi.ts`)
+
+```typescript
+export const inviteApi = {
+  create: (roomId: string) => api.post<RoomInviteResponse>(`/rooms/${roomId}/invites`),
+  getByCode: (code: string) => api.get<RoomInviteResponse>(`/invites/${code}`),
+  join: (code: string) => api.post<ChatRoom>(`/invites/${code}/join`),
+  delete: (code: string) => api.delete(`/invites/${code}`),
+}
+```
+
+#### 3. 타입 (`types/index.ts`)
+
+```typescript
+export interface RoomInviteResponse {
+  roomId: string;
+  roomName: string;
+  inviteCode: string;
+  inviteUrl: string;
+  createdAt?: string;
+}
+```
+
+#### 4. 초대 참여 페이지 (`InvitePage.tsx`)
+
+- Route: `/invite/:code`
+- 초대 정보 표시 (채팅방 이름)
+- "참여하기" 버튼
+- 미로그인 시 로그인 페이지로 리다이렉트 (returnUrl 포함)
+
+#### 5. 채팅방 UI 수정 (`ChatRoom.tsx`)
+
+- 헤더에 "초대 링크" 버튼 추가
+- 클릭 시 inviteApi.create() 호출
+- 클립보드에 링크 복사 + "복사됨" 피드백
+
+#### 6. 라우팅 추가 (`App.tsx`)
+
+```tsx
+<Route path="/invite/:code" element={<InvitePage />} />
+```
+
+## 파일 변경 목록
+
+### Backend (신규)
+- `chatroom/dto/RoomInviteResponse.java`
+- `chatroom/service/RoomInviteService.java`
+- `chatroom/controller/RoomInviteController.java`
+
+### Backend (수정)
+- `config/SecurityConfig.java` - 초대 엔드포인트 권한 설정
+
+### Frontend (신규)
+- `api/inviteApi.ts`
+- `pages/InvitePage.tsx`
+
+### Frontend (수정)
+- `types/index.ts` - RoomInviteResponse 타입 추가
+- `App.tsx` - /invite/:code 라우트 추가
+- `components/chat/ChatRoom.tsx` - 초대 링크 버튼 추가
+- `stores/useChatStore.ts` - fetchRooms 함수 추가
+
+## 수락 조건
+
+- [x] 채팅방에서 "초대 링크" 버튼 클릭 시 초대 링크 생성 및 클립보드 복사
+- [x] 초대 링크 접속 시 채팅방 정보 표시
+- [x] 미로그인 상태에서 초대 링크 접속 시 로그인 페이지로 리다이렉트
+- [x] 로그인 후 초대 링크로 돌아와 "참여하기" 클릭 시 채팅방 참여
+- [x] 이미 참여한 채팅방 초대 링크 접속 시 바로 채팅방으로 이동
+- [x] 잘못된 초대 코드 접속 시 에러 메시지 표시
+- [x] 초대 링크 7일 후 자동 만료
+
+## Labels
+- area: backend
+- area: frontend
+- type: feature
+- medium


### PR DESCRIPTION
## Summary
- 채팅방별 고유 초대 링크 생성 및 공유 기능
- Valkey(Redis) 기반 초대 코드 저장 (7일 TTL 자동 만료)
- 초대 링크를 통한 채팅방 참여 기능

## Changes

### Backend
- `RoomInviteService`: Valkey 기반 초대 코드 CRUD
- `RoomInviteController`: 초대 API 엔드포인트
  - `POST /api/v1/rooms/{roomId}/invites`: 초대 코드 생성
  - `GET /api/v1/invites/{code}`: 초대 정보 조회 (공개)
  - `POST /api/v1/invites/{code}/join`: 초대 코드로 참여
  - `DELETE /api/v1/invites/{code}`: 초대 코드 삭제
- `SecurityConfig`: 초대 정보 조회 공개 설정

### Frontend
- `InvitePage`: 초대 참여 페이지 (`/invite/:code`)
- `inviteApi`: 초대 API 클라이언트
- `ChatRoom`: 초대 링크 복사 버튼 추가

### Bug Fixes
- Reactive Stream 중복 실행 방지 (`.cache()` 연산자 추가)
- 한글 IME 조합 중 Enter 키 처리 (`isComposing` 체크)
- 오프라인 상태 UI 개선 (rose 색상)

## Test plan
- [x] 채팅방에서 "초대 링크" 버튼 클릭 시 링크 생성 및 클립보드 복사
- [x] 초대 링크 접속 시 채팅방 정보 표시
- [x] 미로그인 상태에서 초대 링크 접속 시 로그인 페이지 리다이렉트
- [x] 로그인 후 "참여하기" 클릭 시 채팅방 참여
- [x] 이미 참여한 채팅방 초대 링크 접속 시 바로 이동
- [x] 한글 입력 시 메시지 분리 버그 수정 확인

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)